### PR TITLE
improvement(uikit): add visibility hidden

### DIFF
--- a/__stories__/atomic/VisuallyHidden__Stories.re
+++ b/__stories__/atomic/VisuallyHidden__Stories.re
@@ -1,0 +1,19 @@
+open BsStorybook.Story;
+
+// Bind Module
+module StorybookConst = Constants.Storybook;
+module Action = BsStorybook.Action;
+
+//
+let str = React.string;
+
+let jsModule = [%raw "module"];
+storiesOf(StorybookConst.storiesOf(`Components(`Atomics)), jsModule)
+->(
+    add("Visually Hidden", () =>
+      <View>
+        <Text value="inspect my next element" />
+        <VisuallyHidden> {"Hi i am not visible" |> str} </VisuallyHidden>
+      </View>
+    )
+  );

--- a/src/components/uikit/atomic/VisuallyHidden.re
+++ b/src/components/uikit/atomic/VisuallyHidden.re
@@ -1,0 +1,37 @@
+/**
+ * Provides text for screen readers that is visually hidden. It is the logical opposite of the aria-hidden attribute.
+In the following example, screen readers will announce "Save" and will ignore the icon; the browser displays the icon and ignores the text.
+ */
+
+[@react.component]
+let make = (~children=?, ~tabIndex=0, ~forwardRef=?) => {
+  let style =
+    Css.(
+      style([
+        borderWidth(`zero),
+        unsafe("clip", "rect(0 0 0 0)"),
+        height(`px(1)),
+        margin(`px(-1)),
+        overflow(`hidden),
+        padding(`zero),
+        position(`absolute),
+        width(`px(1)),
+        whiteSpace(`nowrap),
+        wordWrap(`normal),
+      ])
+    );
+  let props =
+    ReactDOMRe.objToDOMProps({
+      "className": style,
+      "tabIndex": tabIndex,
+      "ref": forwardRef,
+    });
+
+  let child =
+    switch (children) {
+    | Some(child) => child
+    | None => React.null
+    };
+
+  ReactDOMRe.createElement("span", ~props, [|child|]);
+};


### PR DESCRIPTION
# Add VisibilityHidden into UIKit

**Describe your Merge Request**
Provides text for screen readers that is visually hidden. It is the logical opposite of the aria-hidden attribute.
In the following example, screen readers will announce "Save" and will ignore the icon; the browser displays the icon and ignores the text.

**Type of change**
Minor

**How has this been tested?**
- [x] Chrome
- [x] Firefox
- [x] Safari

**Checklist**
- [x] Create Visibility hidden

**Screenshoots**
![Screen Shot 2020-03-20 at 12 07 13](https://user-images.githubusercontent.com/16620050/77138303-21a71400-6aa4-11ea-98f7-a84ed0f193b7.png)


