### PR TITLE
improvement(uikit): add column to uikit

### DIFF
--- a/__stories__/atomic/Col__Stories.re
+++ b/__stories__/atomic/Col__Stories.re
@@ -1,0 +1,15 @@
+open BsStorybook.Story;
+
+// Bind Module
+module StorybookConst = Constants.Storybook;
+module Action = BsStorybook.Action;
+
+let str = React.string;
+
+let jsModule = [%raw "module"];
+storiesOf(StorybookConst.storiesOf(`Components(`Atomics)), jsModule)
+->(
+    add("Column", () =>
+      <Col> <Text value="Aloha " /> <Text value="KalselJS" /> </Col>
+    )
+  );

--- a/src/components/uikit/atomic/Col.re
+++ b/src/components/uikit/atomic/Col.re
@@ -1,0 +1,52 @@
+open Utils.Option.Infix;
+
+module Styles = {
+  open Css;
+  let merge = Css.merge;
+  let createBase = (justifyContentValue, alignItemsValue) => {
+    let base = style([flexDirection(`column)]);
+    merge([
+      base,
+      justifyContentValue <$> (v => style([justifyContent(v)])) |? "",
+      alignItemsValue <$> (v => style([alignItems(v)])) |? "",
+    ]);
+  };
+};
+
+[@react.component]
+let make =
+    (
+      ~style="",
+      ~forwardRef=?,
+      ~onScroll=?,
+      ~onPress=?,
+      ~onMouseEnter=?,
+      ~onMouseLeave=?,
+      ~justifyContent=?,
+      ~alignItems=?,
+      ~accessibilityLabel=?,
+      ~accessibilityRole=?,
+      ~accessibilityRoleDescription=?,
+      ~accessibilityLabelledBy=?,
+      ~as_=?,
+      ~id=?,
+      ~children,
+    ) => {
+  let resolvedStyle =
+    [Styles.createBase(justifyContent, alignItems), style]->Css.merge;
+  <View
+    style=resolvedStyle
+    ?forwardRef
+    ?onScroll
+    ?onPress
+    ?onMouseEnter
+    ?onMouseLeave
+    ?accessibilityLabel
+    ?accessibilityRole
+    ?accessibilityRoleDescription
+    ?accessibilityLabelledBy
+    ?id
+    ?as_>
+    children
+  </View>;
+};


### PR DESCRIPTION
# Add column into UIKit

**Describe your Merge Request**
Add column to our uikit

Component API: 

| Api | type  | default value  |
| ------- | --- | --- |
| children | `React.children` |None |
| onSroll | `option(React.eventScroll => unit)` |None |
| onMouseEnter | `option(React.mouseEnter => unit)` | None  |
| onPress | `option(React.eventPropogation => unit)` | None |
| onMouseLeave | `option(React.mouseLeave => unit)` | None |
| accessibilityRole | `option(string)` | None |
| accessibilityLabel | `option(string)` | None |
| accessibilityLabeledby | `option(string)` | None |



How to use it:

```jsx
<Col>
    children
</Col>
```

**Type of change**
Minor

**How has this been tested?**
- [x] Chrome
- [x] Firefox
- [x] Safari

**Checklist**
- [x] Create Column

**Screenshoots**
![Screen Shot 2020-03-21 at 11 59 40](https://user-images.githubusercontent.com/16620050/77219860-5c747f00-6b6c-11ea-9819-113ca2050f60.png)



