### PR TITLE
improvement(uikit): add divider uikit

### DIFF
--- a/__stories__/atomic/Divider__Stories.re
+++ b/__stories__/atomic/Divider__Stories.re
@@ -1,0 +1,25 @@
+open BsStorybook.Story;
+
+// Bind Module
+module StorybookConst = Constants.Storybook;
+module Action = BsStorybook.Action;
+module Spacing = Utils.Styles.Spacing;
+
+let str = React.string;
+
+let jsModule = [%raw "module"];
+storiesOf(StorybookConst.storiesOf(`Components(`Atomics)), jsModule)
+->(
+    add("Divider", () =>
+      <View
+        spacing={Spacing.make(
+          ~pt=`rem(2.),
+          ~pb=`rem(2.),
+          ~pl=`rem(1.),
+          ~pr=`rem(1.),
+          (),
+        )}>
+        <Divider />
+      </View>
+    )
+  );

--- a/src/components/uikit/atomic/Divider.re
+++ b/src/components/uikit/atomic/Divider.re
@@ -1,0 +1,27 @@
+open Utils.Option.Infix;
+
+module Styles = {
+  open Css;
+  let createBase = (~colors: Colors.t, ~customWidth) =>
+    style([
+      height(`px(1)),
+      customWidth <$> (customWidth' => width(customWidth')) |? width(`auto),
+      margin(`rem(1.2)),
+      backgroundColor(colors.primary.lightest),
+    ]);
+};
+
+[@react.component]
+let make = (~width as customWidth=?) => {
+  let colors = React.useContext(Theme.context);
+
+  let props =
+    ReactDOMRe.objToDOMProps({
+      "className": Styles.createBase(~customWidth, ~colors),
+      "aria-label": "divider",
+      "aria-labelledby": "divider",
+      "role": "divider",
+    });
+
+  ReactDOMRe.createElement("div", ~props, [||]);
+};


### PR DESCRIPTION
# Add divider into UIKit

**Describe your Merge Request**
Add divider to our uikit

Component API: 

| Api | type  | default value  |
| ------- | --- | --- |
| width | `Css.Length.t` |`auto` |



How to use it:

```jsx
<Divider />
```

**Type of change**
Minor

**How has this been tested?**
- [x] Chrome
- [x] Firefox
- [x] Safari

**Checklist**
- [x] Create Divider base
- [x] Create Divider with custom props

**Screenshoots**
<img width="1328" alt="Screen Shot 2020-03-21 at 12 41 38" src="https://user-images.githubusercontent.com/16620050/77220459-cf80f400-6b72-11ea-9240-6b3d6f006db9.png">




